### PR TITLE
docs: update tasks/roadmap/tech-stack for Tailwind Option B, repo hygiene, and Next.js spike

### DIFF
--- a/.agent-os/product/roadmap.md
+++ b/.agent-os/product/roadmap.md
@@ -19,6 +19,20 @@
 - [x] Tailwind CSS integration in current vanilla UI (no React): Tailwind CLI wired, `dist/styles.css` linked, theme toggles live.
 - [ ] Chat window layout parity (post‑Tailwind): audit Conversations view and apply minimal, scoped fixes.
 
+### Repo hygiene
+
+- [ ] Protect `main` branch: require PRs, prevent force pushes/deletions, optional status checks
+
+### Conversations UX polish
+
+- [ ] Wire `button[data-action="new-conversation"]` to clear thread and focus composer
+
+### React/Next.js spike (parallel, behind flag)
+
+- [ ] Scaffold `web/` Next.js with Tailwind
+- [ ] Add Electron flag to load Next renderer in dev/prod
+- [ ] Port Conversations view to parity; keep fallback to current renderer
+
 ## Phase 2: Near Term
 - [ ] shadcn/ui components, blocks, themes via React/Next.js when moving from Option B to Option A
 - [ ] RAG sources UI (upload/index/search stubs in frontend)

--- a/.agent-os/product/tech-stack.md
+++ b/.agent-os/product/tech-stack.md
@@ -1,0 +1,37 @@
+# Tech Stack (Project)
+
+## Runtime
+- Electron 30.x (desktop shell)
+- FastAPI (Python 3.10+) on 127.0.0.1 with health checks
+
+## UI
+- Current (Option B active): Vanilla HTML/CSS/JS (`index.html`, `style.css`, `script.js`) with Tailwind base utilities only
+- Tailwind (active): Tailwind CLI builds `dist/styles.css` from `tailwind.css`; linked in `index.html`
+- Target: Next.js 14+ (no Vite, no Docker), Tailwind CSS 4+, shadcn/ui components, blocks, themes
+- Icons: Lucide React
+- Theming: `html[data-theme]` + `--icon-accent` (dark `#049499`, light `#5DE2E7`)
+
+### Migration plan
+- React/Next.js spike will live in `web/` in parallel behind an Electron flag (no impact to current renderer until parity).
+
+## Backend
+- FastAPI + httpx + uvicorn
+- Provider proxies: Ollama (local), Google AI (Gemini), OpenRouter, OpenAI-compatible, Anthropic, Mistral, Groq, Cohere, Azure OpenAI
+- Rate limiting: simple in‑memory (300 req/min/IP)
+- Optional local token guard via `LOCAL_API_TOKEN`
+
+## Tooling
+- Node 20 LTS, npm
+- esbuild for Electron main/preload; Next.js build/runtime for web (no Vite)
+- Tailwind CLI scripts: `npm run css:build`, `npm run css:watch`
+
+## Repo & Workflow
+- Branch protection: protect `main` from force-push/deletion, require PR reviews, and optionally require status checks.
+- Use feature branches and squash-merge PRs into `main` to keep a linear history.
+
+## Hosting / Distribution
+- Desktop: Electron packaged installers (future)
+- Optional web: Next.js server (no Docker)
+
+## Testing
+- `tests/e2e/` for E2E scaffolding; expand for theme and prompts flows

--- a/.agent-os/specs/2025-09-28-category-panel-normalization/tasks.md
+++ b/.agent-os/specs/2025-09-28-category-panel-normalization/tasks.md
@@ -37,7 +37,21 @@ Parent Task 5 — Tailwind CSS integration (vanilla UI, no React)
 
 Parent Task 6 — Chat window layout parity (post‑Tailwind)
 
-- [ ] 6.1 Audit Conversations view elements (header, list card, composer bar, actions) for spacing/position shifts
-- [ ] 6.2 Apply minimal, scoped fixes (utilities or token mapping) to restore original layout
-- [ ] 6.3 Verify Light/Dark/System parity and hover/focus states
+- [x] 6.1 Audit Conversations view elements (header, list card, composer bar, actions) for spacing/position shifts
+- [x] 6.2 Apply minimal, scoped fixes (utilities or token mapping) to restore original layout
+- [x] 6.3 Verify Light/Dark/System parity and hover/focus states
 - [ ] 6.4 Regression pass on other routes (no visual drift)
+
+Parent Task 7 — Repo hygiene
+
+- [ ] 7.1 Protect `main` branch: require PRs, prevent force pushes/deletions, optional status checks
+
+Parent Task 8 — Conversations UX polish
+
+- [ ] 8.1 Wire `button[data-action="new-conversation"]` to clear thread and focus composer
+
+Parent Task 9 — React/Next.js spike (parallel, behind flag)
+
+- [ ] 9.1 Scaffold `web/` Next.js with Tailwind
+- [ ] 9.2 Add Electron flag to load Next renderer in dev/prod
+- [ ] 9.3 Port Conversations view to parity; keep fallback to current renderer


### PR DESCRIPTION
Docs updates
- tasks.md: mark chat parity subtasks, add repo hygiene, Conversations UX polish, and React/Next.js spike tasks
- roadmap.md: add corresponding sections and keep Option B status
- tech-stack.md: clarify Option B is active, add migration plan and repo workflow notes

No code changes beyond docs.

Requesting a small merge to main to keep documentation current.